### PR TITLE
fix(code-quality): Fix for Explicit returns mixed with implicit (fall through) returns

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -187,8 +187,7 @@ def redirect_url(arg):
             hashsum = hashlib.sha256(requested_path.encode("utf-8")).hexdigest()
             url_bytes, salt_bytes = db.get_link(hashsum)
             if url_bytes is False:
-                abort(HTTPStatus.NOT_FOUND)
-                return None
+                return page_not_found(HTTPStatus.NOT_FOUND)
             else:
                 db.increment_click(hashsum)
                 newlink = urls.decrypt_url(
@@ -198,6 +197,8 @@ def redirect_url(arg):
                     render_template("redirect.html", link=newlink, tld=tld, cdn=cdn)
                 )
                 return resp
+
+    return internal_server_error(HTTPStatus.INTERNAL_SERVER_ERROR)
 
 
 @application.after_request

--- a/app/app.py
+++ b/app/app.py
@@ -115,6 +115,7 @@ def input_url():
                         elif message is not None:
                             # 500 error returned for database failure
                             abort(HTTPStatus.INTERNAL_SERVER_ERROR)
+                            return None
 
                 # Return link page with URL if successful
                 resp = make_response(


### PR DESCRIPTION
General fix: ensure `redirect_url` has an explicit return for all code paths, and avoid `return None` after `abort()` in view functions. In Flask handlers, either return a valid response object/string/tuple or raise via `abort()`.

Best fix in this file: in `app/app.py`, inside `redirect_url` (around lines 167–201), replace the `abort(...); return None` block with a direct `return page_not_found(...)` using the existing error handler function. This guarantees an explicit Flask response object on that branch and removes the problematic `None` return path. Also add a final defensive return after the `match` to ensure an explicit response in all analyzer-visible paths.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._