### PR TITLE
fix(code-quality): Fix for Explicit returns mixed with implicit (fall through) returns

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -138,8 +138,9 @@ def input_url():
 
         case _:
             # Catch all to return 500 error for any unexpected cases
-            abort(HTTPStatus.INTERNAL_SERVER_ERROR)
-            return None
+            return internal_server_error(HTTPStatus.INTERNAL_SERVER_ERROR)
+
+    return internal_server_error(HTTPStatus.INTERNAL_SERVER_ERROR)
 
 
 @application.route("/<arg>/stats")


### PR DESCRIPTION
To fix this, make `input_url()` total: every control-flow path must explicitly return a response or raise via `abort`.  
Best minimal fix without changing behavior: add a final fallback return after the `match` in `input_url()` that returns the existing 500 handler response. This prevents implicit `None` return if any path in the `"POST"` branch ever falls through.

Edit in **`app/app.py`**, inside `input_url()`:
- Keep existing logic unchanged.
- Replace the unreachable `return None` after `abort(...)` in `case _` with a concrete response return (or remove it), and
- Add/retain a final explicit `return internal_server_error(HTTPStatus.INTERNAL_SERVER_ERROR)` at function end so no implicit return is possible.

No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._