### PR TITLE
fix(database): Fixed database persistency issues

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -195,10 +195,22 @@ def redirect_url(arg):
                 return page_not_found(HTTPStatus.NOT_FOUND)
             else:
                 db.increment_click(hashsum)
-                newlink = urls.decrypt_url(
-                    url_bytes, requested_path, salt_bytes
-                ).decode("utf-8")
+                decrypted = urls.decrypt_url(url_bytes, requested_path, salt_bytes)
+                if decrypted is False:
+                    logging.error(
+                        "decrypt_url failed for path=%s — BLOB data may be corrupt "
+                        "or the driver returned an unexpected type.",
+                        requested_path,
+                    )
+                    abort(HTTPStatus.INTERNAL_SERVER_ERROR)
+                newlink = decrypted.decode("utf-8")
                 if not newlink.startswith("https://"):
+                    logging.error(
+                        "Decrypted URL for path=%s does not start with https:// — "
+                        "possible data corruption. Value: %.100r",
+                        requested_path,
+                        newlink,
+                    )
                     return page_not_found(HTTPStatus.NOT_FOUND)
                 resp = make_response(
                     render_template("redirect.html", link=newlink, tld=tld, cdn=cdn)

--- a/app/gunicorn_cfg.py
+++ b/app/gunicorn_cfg.py
@@ -1,9 +1,20 @@
 """Configuration module for Gunicorn, used from: https://dev.to/lionelmarco/how-to-add-flask-gunicorn-packages-to-a-distroless-docker-container-2ml2"""
 
+import logging
 import multiprocessing
+import os
 
 import gunicorn.app.base
 from app import application
+
+# Configure the root logger so all modules (turso_mgmt, url_mgmt, etc.) emit
+# at the level defined by the LOG_LEVEL env var (default: INFO).
+# Set LOG_LEVEL=DEBUG locally to see BLOB-type debug lines.
+_log_level = os.environ.get("LOG_LEVEL", "INFO").upper()
+logging.basicConfig(
+    level=getattr(logging, _log_level, logging.INFO),
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
 
 
 def number_of_workers():
@@ -35,5 +46,6 @@ if __name__ == "__main__":
         "bind": "%s:%s" % ("0.0.0.0", "8080"),
         "workers": number_of_workers(),
         "worker_tmp_dir": "/tmp",
+        "loglevel": _log_level.lower(),
     }
     StandaloneApplication(application, options).run()

--- a/app/turso_mgmt.py
+++ b/app/turso_mgmt.py
@@ -3,7 +3,7 @@
 import logging
 from datetime import datetime, timezone
 from os import environ
-from re import search
+from re import IGNORECASE, search
 
 import turso.sync
 from dotenv import load_dotenv
@@ -17,9 +17,58 @@ DB_PATH = "/tmp/urls.db"
 
 def _create_connection():
     """Creates and returns a new database connection."""
-    conn = turso.sync.connect(DB_PATH, remote_url=url, auth_token=auth_token)
-    conn.pull()
-    return conn
+    try:
+        conn = turso.sync.connect(DB_PATH, remote_url=url, auth_token=auth_token)
+        conn.pull()
+        return conn
+    except Exception as e:
+        logging.error("Failed to create database connection or pull replica: %s", e)
+        raise
+
+
+def _coerce_blob(value, field_name: str) -> bytes:
+    """Coerce a database BLOB value to bytes.
+
+    pyturso may return BLOB columns as bytes, memoryview, or (in some driver
+    versions) a base64-encoded string.  Stringifying an arbitrary object with
+    ``bytes(str(obj), 'utf-8')`` produces garbage such as ``b'<memory at
+    0x…>'``, which silently corrupts Fernet decryption.  This helper handles
+    all known return types safely.
+    """
+    if isinstance(value, bytes):
+        return value
+    if isinstance(value, memoryview):
+        logging.debug("BLOB field '%s' returned as memoryview — converting", field_name)
+        return bytes(value)
+    if isinstance(value, bytearray):
+        logging.debug("BLOB field '%s' returned as bytearray — converting", field_name)
+        return bytes(value)
+    if isinstance(value, str):
+        # Some driver versions return BLOBs as base64 strings.
+        logging.warning(
+            "BLOB field '%s' returned as str — attempting base64 decode. "
+            "Raw value (first 60 chars): %.60r",
+            field_name,
+            value,
+        )
+        try:
+            import base64 as _base64
+
+            return _base64.b64decode(value)
+        except Exception as decode_err:
+            logging.error(
+                "BLOB field '%s': base64 decode failed (%s). "
+                "Falling back to raw UTF-8 encoding — decryption will likely fail.",
+                field_name,
+                decode_err,
+            )
+            return value.encode("utf-8")
+    logging.error(
+        "BLOB field '%s' has unexpected type %s — coercion may be incorrect.",
+        field_name,
+        type(value).__name__,
+    )
+    return bytes(value)
 
 
 def get_link(hashsum: str):
@@ -32,16 +81,17 @@ def get_link(hashsum: str):
         row = result_set.fetchone()
 
         if row:
-            # Ensure data is returned as bytes, adjust if your schema stores them differently
-            url_data = (
-                row[0] if isinstance(row[0], bytes) else bytes(str(row[0]), "utf-8")
+            logging.debug(
+                "get_link raw types — url: %s, salt: %s",
+                type(row[0]).__name__,
+                type(row[1]).__name__,
             )
-            salt_data = (
-                row[1] if isinstance(row[1], bytes) else bytes(str(row[1]), "utf-8")
-            )
+            url_data = _coerce_blob(row[0], "url")
+            salt_data = _coerce_blob(row[1], "salt")
             return url_data, salt_data
+        logging.info("get_link: no row found for hashsum %s", hashsum)
         return False, False
-    except Exception as e:  # Use specific or general exception
+    except Exception as e:
         logging.error("Error on get_link: %s", e)
         return False, False
     finally:
@@ -51,7 +101,6 @@ def get_link(hashsum: str):
 
 def insert_link(hashsum: str, url: bytes, salt: bytes):
     """Insert an entry under the specified path, return bool outcome"""
-    unique_error = "UNIQUE constraint failed: urls.HASHSUM"
     conn = _create_connection()
     try:
         # Insert entry
@@ -63,7 +112,9 @@ def insert_link(hashsum: str, url: bytes, salt: bytes):
         conn.commit()
         return True, None
     except Exception as e:  # Changed from Error to a more general Exception
-        if search(unique_error, str(e)):
+        # Match case-insensitively — the driver may return the column name in
+        # any case (e.g. "urls.HASHSUM" vs "urls.hashsum").
+        if search(r"UNIQUE constraint failed: urls\.hashsum", str(e), IGNORECASE):
             logging.warning("Entry already exists: %s", e)
             return False, "non-unique"
         logging.error("Error on insert_link: %s", e)


### PR DESCRIPTION
BLOB coercion fix — replaced the broken bytes(str(obj), "utf-8") fallback in get_link with a proper _coerce_blob() helper that correctly handles memoryview, bytearray, and base64 strings returned by the pyturso driver, preventing silent Fernet decryption failures on links created before a cold start.

Duplicate extension detection fix — the UNIQUE constraint error string from the driver uses lowercase (urls.hashsum) but the original check matched uppercase only, causing duplicate custom extensions to return a 500 instead of the "already taken" toast. Fixed with a case-insensitive regex match.

Logging improvements — added structured error logging to _create_connection, get_link, and the decryption path in app.py; configured gunicorn_cfg.py to call logging.basicConfig at startup (so log messages are actually emitted under Gunicorn) with the level controllable via LOG_LEVEL env var.

BREAKING CHANGE: